### PR TITLE
Possible typos

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -20,6 +20,7 @@ jobs:
           cat << EOF > .markdownlint.json
             {
               "default": true,
+              "MD013": false,
               "MD026": false,
               "MD029": {"style": "ordered" },
               "MD033": false,

--- a/Tao.md
+++ b/Tao.md
@@ -113,7 +113,7 @@ thought-provoking email messages.
 
 Of course, it's true that many IETF participants don't go to the face-to-face
 meetings at all - especially since the COVID-19 pandemic when meetings were
-completely online for a while. There also also many participants that solely
+completely online for a while. There also many participants that solely
 focus on the mailing lists of various IETF Working Groups. Since the inner
 workings of Working Groups can be hard for newcomers to understand, this
 document provides the mundane bits of information that newcomers will need in
@@ -307,7 +307,7 @@ throughout the world." One of the ways that ISOC does this is through
 support of the IETF.
 
 The [IETF Administration LLC](https://www.ietf.org/about/administration/) (IETF LLC) is a "disregarded entity" of ISOC, which means it is treated as
-as a branch or division for tax purposes. The IETF LLC has no role in the
+a branch or division for tax purposes. The IETF LLC has no role in the
 oversight or steering of the standards process, the appeal chain, the
 confirming bodies for existing IETF and IAB appointments, the IRTF, or ISOC's
 memberships in other organizations. Rather, the IETF LLC, as overseen by its
@@ -1444,7 +1444,7 @@ Call comments that come from people who have just read the document for the
 first time can expose issues that IETF and WG regulars may have completely
 missed, which is why the discussion is open to everyone.
 
-Finally, the draft is given to the RPC Production Center (RPC), and prepared
+Finally, the draft is given to the RFC Publication Center (RPC), and prepared
 for publication. There might be other changes required, including  reviews by
 IANA for registrations and the like. The most common item you'll hear about
 this is *AUTH48* state, which means the document is in the final stages of
@@ -1797,7 +1797,7 @@ get a piece of the action. In general, the IETF tries to have cordial
 relationships with other SDOs. This isn't always easy, since they usually
 have different structures and processes than the IETF does, and the IETF is
 mostly run by volunteers who would probably prefer to write standards rather
-than meet with representatives from other bodies. Even so, man SDOs make a
+than meet with representatives from other bodies. Even so, many SDOs make a
 great effort to interact well with the IETF despite the obvious cultural
 differences.
 

--- a/Tao.md
+++ b/Tao.md
@@ -39,7 +39,7 @@ document but an informal and informational overview.
 2.2.2 <a href="#2-2-2">Internet Engineering Steering Group (IESG)</a><br>
 2.2.3 <a href="#2-2-3">Internet Architecture Board (IAB)</a><br>
 2.2.4 <a href="#2-2-4">Internet Assigned Numbers Authority (IANA)</a><br>
-2.2.5 <a href="#2-2-5">RFC Editor and RFC Publication Center (RPC)</a><br>
+2.2.5 <a href="#2-2-5">RFC Editor and RFC Production Center (RPC)</a><br>
 2.2.6 <a href="#2-2-6">IETF Secretariat</a><br>
 2.2.7 <a href="#2-2-7">IETF Trust</a><br>
 2.3 <a href="#2-3">IETF Mailing Lists</a><br>
@@ -463,7 +463,7 @@ about messing things up.
 
 <a id="2-2-5"></a>
 
-#### 2.2.5 RFC Editor and RFC Publication Center (RPC)
+#### 2.2.5 RFC Editor and RFC Production Center (RPC)
 
 The RPC edits, formats, and published RFC's. This used to be done by one
 person, which is why you will still see the term *RFC Editor*; IETFers are
@@ -1444,7 +1444,7 @@ Call comments that come from people who have just read the document for the
 first time can expose issues that IETF and WG regulars may have completely
 missed, which is why the discussion is open to everyone.
 
-Finally, the draft is given to the RFC Publication Center (RPC), and prepared
+Finally, the draft is given to the RFC Production Center (RPC), and prepared
 for publication. There might be other changes required, including  reviews by
 IANA for registrations and the like. The most common item you'll hear about
 this is *AUTH48* state, which means the document is in the final stages of

--- a/Tao.md
+++ b/Tao.md
@@ -1408,15 +1408,15 @@ adoption*. If consensus is to adopt the draft, you will be asked to submit
 it with the name `draft-ietf-WGNAME-brief-subject`; you can probably guess
 what *WGNAME* should be.
 
-Note that as part of submitting an Internet Draft according to the rules, you 
-grant the IETF certain rights.  These rights give the IETF the ability to 
-reliably build upon the work you have brought forward. These rights are held 
+Note that as part of submitting an Internet Draft according to the rules, you
+grant the IETF certain rights.  These rights give the IETF the ability to
+reliably build upon the work you have brought forward. These rights are held
 by the IETF Trust.
 
-Once a WG adopt a document, the WG as a whole has the right of "change 
-control." This means the WG, can make any changes to the document, the one 
-you initially wrote, that they want. If you are not comfortable with this, 
-then the IETF is not the place for your document. There are a few more 
+Once a WG adopt a document, the WG as a whole has the right of "change
+control." This means the WG, can make any changes to the document, the one
+you initially wrote, that they want. If you are not comfortable with this,
+then the IETF is not the place for your document. There are a few more
 details on this <a href="#copyright">below</a>.
 
 The WG now "works on" the document. This will be a combination of
@@ -1655,7 +1655,7 @@ explicit privacy section.
 Some drafts benefit from having an "Implementation Status" section,
 as explained by <a href="https://www.rfc-editor.org/info/rfc7942">
 BCP 205: Improving Awareness of Running Code: The Implementation Status
-Section</a>. 
+Section</a>.
 
 More detail on the required content can be found
 [online](https://authors.ietf.org/en/required-content)</a>.


### PR DESCRIPTION
Thank you very much for editing such a useful document.  I found four possible typos.  Because I'm neither a native English speaker nor an active IETFer, I'm sorry if some or all of them are correct.

Here's a summary of possible typos.
1. "also also" -> "also"
2. "as as" -> "as"
3. "the RPC Production Center (RPC)" -> "the RFC Publication Center (RPC)"
4. "man SDOs" -> "many SDOs"