### PR TITLE
Fix MD009 markdownlint failures.

### DIFF
--- a/Tao.md
+++ b/Tao.md
@@ -1408,10 +1408,10 @@ adoption*. If consensus is to adopt the draft, you will be asked to submit
 it with the name `draft-ietf-WGNAME-brief-subject`; you can probably guess
 what *WGNAME* should be.
 
-Note that as part of submitting an Internet Draft according to the rules, you 
-grant the IETF certain rights.  These rights give the IETF the ability to 
-reliably build upon the work you have brought forward. These rights are held 
-by the IETF Trust. [BCP 78](https://www.rfc-editor.org/rfc/rfc5378.html) 
+Note that as part of submitting an Internet Draft according to the rules, you
+grant the IETF certain rights.  These rights give the IETF the ability to
+reliably build upon the work you have brought forward. These rights are held
+by the IETF Trust. [BCP 78](https://www.rfc-editor.org/rfc/rfc5378.html)
 explains the certain rights the IETF Trust takes on for submissions.
 
 Once a WG adopt a document, the WG as a whole has the right of "change


### PR DESCRIPTION
Lint Markdown fails with the following error messages.

Tao.md:1411:78 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
Tao.md:1412:74 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
Tao.md:1413:77 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
Tao.md:1414:73 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]

To deal with them, four trailing spaces in Tao.md need to be removed.

Reference: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md