### PR TITLE
Update markdownlint.yml

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -11,7 +11,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+        
+    - name: Setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
 
     - name: Locate or create markdownlint config
       run: |


### PR DESCRIPTION
The Github actions have not been running properly for a while ("Node.js 12 actions are deprecated." - e.g: https://github.com/ietf/tao/actions/runs/3473787357) . This should fix them